### PR TITLE
Fix: mosaic mix transform

### DIFF
--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -102,10 +102,11 @@ class BaseMixTransform:
         ########
 
         elif self.dataset.together:
-            mix_labels_list = []
-            for count in range(len(indexes)):
-                tem_list = [file[count] for file in mix_labels]
-                mix_labels_list.append(tem_list)
+            mix_labels_list = list(zip(*mix_labels))
+            # mix_labels_list = []
+            # for count in range(len(indexes)):
+            #     tem_list = [file[count] for file in mix_labels]
+            #     mix_labels_list.append(tem_list)
 
         if self.pre_transform is not None:
             for mix_labels in mix_labels_list:


### PR DESCRIPTION
in this line we are transposing mix_labels (col->rows), making assumption len(indexes) == len(mix_labels[0]), but when I tried to train with a model with only detection and lane segmentation heads, (not drivable area), this was breaking up, since labels were only 2 but mixup indexes were 3

this one line fixed it.